### PR TITLE
Fix sideBar display error after screen resolution changed

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -269,7 +269,11 @@ void Widget::onResolutionChanged(int argc)
     m_nScreenWidth = screenRect.width();
     m_nScreenHeight = screenRect.height() - connectTaskBarDbus();
     qInfo() << "screen width:" << m_nScreenWidth << ",height:" << m_nScreenHeight;
-
+    //if screen resolution changed while sidebar is visiable, sidebar could be display at unexpected places
+    if(this->isVisible())
+    {
+        this->setGeometry(m_nScreenWidth - 400,0,400,m_nScreenHeight);
+    }
     return;
 }
 


### PR DESCRIPTION
if screen resolution changed while sidebar is visiable, sidebar could be display at unexpected places( see this [issue](https://github.com/ukui/ukui-sidebar/issues/2)). So sidebar's position should be specified after screen resolution changed.
So I think when resolution changed, which means function `void Widget::onResolutionChanged(int argc)` in file widget.cpp is triggered, we should also specify the geometry if sidebar is visible. 