### PR TITLE
add support for travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+dist: bionic
+compiler: g++
+sudo: required
+
+before_install:
+  - sudo add-apt-repository -y ppa:beineri/opt-qt-5.12.7-bionic
+  - sudo apt-get update
+
+install:
+  - sudo apt-get install -y qt512base qt512svg qt512charts-no-lgpl qt512xmlpatterns qt512tools
+  - sudo apt-get install -y g++ cmake clang-format make debhelper-compat libglib2.0-dev libqt5svg5-dev qttools5-dev-tools mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev
+  - source /opt/qt512/bin/qt512-env.sh
+
+script:
+  - qmake
+  - make


### PR DESCRIPTION
Currently there's no CI automation system attached to this repo. This pr is going to add Travis-CI support for auto-compiling, which will be triggered for each pr or push. CI automation would make the failure as early as possible and help reviewer to ease their workloads that a pr could be merged only it has passed all the CI checks. Hooray!~

For I have no rights to enable the Travis-CI support for the projects under UKUI organization. So I've made a test passed within the project I forked, see https://github.com/imjoey/ukui-sidebar/pull/1 for details. So is that possible to grant me the rights to configure Travis CI for the projects under UKUI organization? Looking forward to your replies, thanks.
