### PR TITLE
Fix header file missing when build on Archlinux

### DIFF
--- a/src/plugins/Clock_deamon/QRoundProgressBar.cpp
+++ b/src/plugins/Clock_deamon/QRoundProgressBar.cpp
@@ -20,6 +20,7 @@
 #include "QRoundProgressBar.h"
 
 #include <QtGui/QPainter>
+#include <QtGui/QPainterPath>
 #include <QDebug>
 
 


### PR DESCRIPTION
Fix build failed:
```
ukui-sidebar/src/plugins/Clock_deamon/QRoundProgressBar.cpp:269:18: error: aggregate ‘QPainterPath dataPath’ has incomplete type and cannot be defined
  269 |     QPainterPath dataPath;
      |                  ^~~~~~~~
```