### PR TITLE
Solve the problem of incorrect font display in the notification bar

### DIFF
--- a/src/plugins/ukui-sidebar-notification/singlemsg.cpp
+++ b/src/plugins/ukui-sidebar-notification/singlemsg.cpp
@@ -390,7 +390,7 @@ void SingleMsg::setBodyLabelWordWrap(bool bFlag)
     m_pBodyLabel->setWordWrap(bFlag);
     QFont font14;
     font14.setPixelSize(14);
-    m_pBodyLabel->setFont(font14);
+   // m_pBodyLabel->setFont(font14);
     QFontMetrics fontMetrics(m_pBodyLabel->font());
     QString strLineHeight24Body;
     strLineHeight24Body.append("<p style='line-height:24px'>").append(m_strBody).append("</p>");


### PR DESCRIPTION
解决通知条点击字体显示不正确问题