### PR TITLE
bug47199【闹钟】点击菜单-设置，查看设置界面“静音”按钮出现滑动的现象

### DIFF
--- a/src/plugins/ukui-clock/clock.cpp
+++ b/src/plugins/ukui-clock/clock.cpp
@@ -2786,9 +2786,9 @@ void Clock::setUpPage()
         setup_page->ui->pushButton->setStyleSheet("border-image: url(:/alarm_off.png);");
     }
     if (model_setup->index(0, 1).data().toInt()) {
-        setup_page->muteBtn->openSlot();
+        setup_page->muteBtn->initOpen();
     } else {
-        setup_page->muteBtn->closeSlot();
+        setup_page->muteBtn->initClose();
     }
     setup_page->ui->horizontalSlider->setValue(model_setup->index(0, 6).data().toInt());
 


### PR DESCRIPTION
[产生原因]
无
[解决方案]
muteBtn初始化使用initOpen而不是openSlot
[解决版本]
ukui-sidebar > 3.1.0-1-0008
[其他影响]
无

