### PR TITLE
bug46939双屏扩展模式下闹钟的提示弹窗未显示在桌面右下角

### DIFF
--- a/src/plugins/ukui-clock/clock.cpp
+++ b/src/plugins/ukui-clock/clock.cpp
@@ -2027,7 +2027,8 @@ void Clock::countdownNoticeDialogShow()
     if (model_setup->index(0, 3).data().toInt()) {
         countdownNoticeDialog->showFullScreen();
     } else {
-        countdownNoticeDialog->move(screen_width-350,screen_height-150);
+        moveUnderMultiScreen(SP_RIGHT);
+//        countdownNoticeDialog->move(screen_width-350,screen_height-150);
     }
     countdownNoticeDialog->music->setVolume(model_setup->index(0, 6).data().toInt());
     countdownNoticeDialog->timer->start();
@@ -3024,6 +3025,34 @@ void Clock::showPaint8()
         QPainterPath painterPath;
         painterPath.addRoundedRect(rect, 4, 4);
         painter.drawPath(painterPath);
+    }
+}
+
+void Clock::moveUnderMultiScreen(Clock::ScreenPosition spostion)
+{
+    QScreen *screen=QGuiApplication::primaryScreen ();
+    int screen_width = screen->geometry().width();
+    int screen_height = screen->geometry().height();
+    switch (spostion) {
+    case SP_LEFT:
+    {
+        QPoint po = this->geometry().bottomLeft();
+        countdownNoticeDialog->move(po.x(),po.y());
+    }break;
+    case SP_RIGHT:
+    {
+
+        QPoint po = this->geometry().bottomRight();
+        //略微调整下右下角
+        countdownNoticeDialog->move(po.x()+screen_width/4,po.y());
+    }break;
+    case SP_CENTER:
+    {
+        QPoint po = this->geometry().center();
+        countdownNoticeDialog->move(po);
+    }break;
+    default:
+    {}
     }
 }
 

--- a/src/plugins/ukui-clock/clock.h
+++ b/src/plugins/ukui-clock/clock.h
@@ -131,7 +131,13 @@ public:
     void showPaint1();
     void showPaint7();
     void showPaint8();
+    enum ScreenPosition {
+        SP_LEFT = 1,
+        SP_CENTER,
+        SP_RIGHT
+    };
 
+    void moveUnderMultiScreen(Clock::ScreenPosition);                                    //多显示器下，位置移动
     Ui::Clock *ui;
     QSqlTableModel *model_setup;
 


### PR DESCRIPTION
[产生原因]
左扩展平下的显示异常
[解决方案]
根据闹钟的位置，定位右下角的位置。
[解决版本]
ukui-sidebar > 3.1.0-1-0008
[其他影响]
无

bug
http://172.17.66.192/biz/bug-view-46939.html